### PR TITLE
Create minimal "DIY" prod Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM phusion/passenger-ruby21
+
+USER app
+WORKDIR /home/app
+RUN git clone https://github.com/atheiman/better-chef-rundeck
+WORKDIR /home/app/better-chef-rundeck
+RUN bash -c 'sed -i"" -e "/passenger/s/~> 5.0/= $(passenger --version | grep -o '5.*')/" Gemfile' && \
+    cat Gemfile && bundle update passenger && \
+    bundle install
+
+USER root
+RUN echo 'server {\n\
+  listen 80;\n\
+  root /home/app/better-chef-rundeck/public;\n\
+  passenger_enabled on;\n\
+  passenger_user app;\n\
+}\n' > /etc/nginx/sites-enabled/chef-rundeck
+RUN rm /etc/nginx/sites-enabled/default && rm /etc/service/nginx/down


### PR DESCRIPTION
This is more useful as an outsider who wants to run the app in a container without cloning, building and pushing to a docker repo first

a slightly more conventional approach would look more like

``` Dockerfile
FROM phusion/passenger-ruby21

USER app
COPY Gemfile* /home/app/better-chef-rundeck
WORKDIR /home/app/better-chef-rundeck
# pin to the already installed version of passenger
RUN bash -c 'sed -i"" -e "/passenger/s/~> 5.0/= $(passenger --version | grep -o '5.*')/" Gemfile' && \
    bundle install
COPY . /home/app/better-chef-rundeck

USER root
RUN echo 'server {\n\
  listen 80;\n\
  root /home/app/better-chef-rundeck/public;\n\
  passenger_enabled on;\n\
  passenger_user app;\n\
}\n' > /etc/nginx/sites-enabled/chef-rundeck
RUN rm /etc/nginx/sites-enabled/default && rm /etc/service/nginx/down
```

probably also moving nginx config out to a separate file and `COPY`ing it in 

in either case one wants to 

`docker build -t better-chef-rundeck .`
`docker run -d -p 80 -v $HOME/.chef:/home/app/.chef better-chef-rundeck`
