### PR TITLE
Support append_'ing to returned attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,38 @@ nodec:
   username: ${option.username}
 ```
 
+## `append_`ing Attributes
+
+In order to append static text to node attributes, set the GET parameter `append_<attr>=<value>` to append `<value>` to `<attr>` (you can combine this with `default_` or `override_`).
+
+A use case for `append_` attributes is setting the SSH port of nodes (in case all your nodes have non-standard SSH ports)
+
+To illustrate this, three Chef nodes with different attributes (some attributes unset, some `nil`):
+
+```yaml
+---
+nodea:
+  fqdn: nodea
+nodeb:
+  fqdn: nodeb
+nodec:
+  fqdn: nodec
+```
+
+This request would return something similar to the following:
+
+```yaml
+# GET /*:*?hostname=fqdn&append_hostname=:22222
+
+---
+nodea:
+  fqdn: nodea:22222
+nodeb:
+  fqdn: nodeb:22222
+nodec:
+  fqdn: nodec:22222
+```
+
 # Contributing
 
 1. Fork the repo in GitHub

--- a/lib/better_chef_rundeck.rb
+++ b/lib/better_chef_rundeck.rb
@@ -40,7 +40,7 @@ class BetterChefRundeck < Sinatra::Base
 
   # parse params hash for default_ and override_ keys
   def get_defaults_overrides params_hsh
-    defaults, overrides = {}, {}
+    defaults, overrides, appends = {}, {}, {}
     params_hsh.each do |k, v|
       if k.match(/^default_.+/)
         defaults[k.sub(/^default_/, '')] = v
@@ -48,9 +48,12 @@ class BetterChefRundeck < Sinatra::Base
       elsif k.match(/^override_.+/)
         overrides[k.sub(/^override_/, '')] = v
         params_hsh.delete k
+      elsif k.match(/^append_.+/)
+        appends[k.sub(/^append_/, '')] = v
+        params_hsh.delete k
       end
     end
-    return params_hsh, defaults, overrides
+    return params_hsh, defaults, overrides, appends
   end
 
   # build a filter result for a chef partial search from the params hash
@@ -92,7 +95,7 @@ class BetterChefRundeck < Sinatra::Base
     params_clone = clean_params params
 
     # set defaults and overrides from GET params
-    params_clone, defaults, overrides = get_defaults_overrides params_clone
+    params_clone, defaults, overrides, appends = get_defaults_overrides params_clone
 
     # build a filter result for a chef partial search from the remaining GET params
     filter_result = get_filter_result params_clone
@@ -114,6 +117,8 @@ attribute to the attribute path `#{params['name']}` in your GET parameters \
       node.merge!(defaults) { |_key, node_val, default_val| default_val if node_val.nil? }
       # merge in override attributes (overwrite all node attributes)
       node.merge!(overrides)
+      node.merge!(appends) { |_key, node_val, append_val| "#{node_val}#{append_val}" unless node_val.nil? }
+
       formatted_nodes[node.delete('name')] = node
     end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -69,6 +69,18 @@ describe BetterChefRundeck do
         {"node-1"=>{"ipaddress"=>nil, "fqdn"=>nil, "deep_attr"=>0}}
       )
     end
+
+    it 'appends values when using append_ variable names' do
+      get '/chef_environment:env_one?hostname=name&append_hostname=.example.com'
+      expect(last_response).to be_ok
+      expect(last_response.headers['Content-Type']).to match(%r{text\/yaml})
+      nodes = YAML.safe_load(last_response.body)
+      expect(nodes).to eq(
+        'node-1' => {
+          'hostname' => 'node-1.example.com'
+        }
+      )
+    end
   end
 
   after(:context) do


### PR DESCRIPTION
We had the need to return a hostname with a non-standard SSH port appended. This PR adds this functionality.